### PR TITLE
Fixed redirect if location.pathname + "/" == basepath

### DIFF
--- a/history.js
+++ b/history.js
@@ -693,6 +693,9 @@
 				if ( relative != basepath && (new RegExp( "^" + basepath + "$", "i" )).test( path ) ) {
 					windowLocation.href = relative;
 				}
+				if ((new RegExp( "^" + basepath + "$", "i" )).test( path + '/' )){
+					windowLocation.href = basepath;
+				}else
 				if ( !(new RegExp( "^" + basepath, "i" )).test( path ) ) {
 					windowLocation.href = path.replace(/^\//, basepath ) + search;
 				}


### PR DESCRIPTION
If basepath = "/path/" and current url = "http://site.com/path", redirected href will be http://site.com/path/path. This fixed to http://site.com/path/
