### PR TITLE
Add component.json for Bower compatibility

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,8 @@
+{
+  "name": "history",
+  "version": "3.2.1",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/devote/HTML5-History-API"
+  }
+}


### PR DESCRIPTION
This patch adds a simple `component.json` to allow HTML5-History-api to be registered in [Bower's registry](http://twitter.github.com/bower/) by performing the following:

``` bash
npm -g install bower
bower register history git://github.com/devote/HTML5-History-API
```
