### PR TITLE
Fix isolation of pushState and replaceState

### DIFF
--- a/history.js
+++ b/history.js
@@ -757,7 +757,7 @@
 		return change;
 	})();
 
-	History.pushState = function( state, title, url, replace ) {
+	function localPushState( state, title, url, replace ) {
 
 		var
 			stateObject = historyStorage(),
@@ -793,8 +793,12 @@
 		}
 	}
 
+	History.pushState = function( state, title, url) {
+		localPushState( state, title, url );
+	}
+
 	History.replaceState = function( state, title, url ) {
-		History.pushState( state, title, url, 1 );
+		localPushState( state, title, url, 1 );
 	}
 
 	if ( VBInc ) {


### PR DESCRIPTION
If some user want add own hook on pushState:

```
oldPush = history.pushState;
history.pushState = function(state, title, url) {
    oldPush(state, title, url);
    document.title = title;
}
```

He will face up with problem that replaceState now work as pushState.

Private localPushState function solves this problem.

Also if some not attentive user write pushState(state, title, url, some)
he also face up with the same problem.

Function for pushState solves this problem.
