### PR TITLE
add simple test illustrating hashchange event breakage

### DIFF
--- a/test/test_hashchange.js
+++ b/test/test_hashchange.js
@@ -1,0 +1,25 @@
+QUnit.asyncTest('update window.location.hash', function(assert) {
+  var onhashchange = null,
+      wait_time = 14; // a reasonable wait time
+
+  expect(1);
+
+  // first reset hash in case we are re-running test
+  // this can be removed without affecting test results
+  // as long as you load the page fresh
+  window.location.hash = '';
+
+  setTimeout(function() {
+    window.addEventListener('hashchange', function(e) {
+      onhashchange = e;
+    }, false);
+
+    window.location.hash = "#/path";
+
+    // allow onhashchange to fire
+    setTimeout(function() {
+      assert.ok(onhashchange != null, "hashchange event was not fired!"); 
+      QUnit.start();
+    }, wait_time);
+  }, wait_time);
+});

--- a/test/test_hashchange_html5.html
+++ b/test/test_hashchange_html5.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>QUnit Example</title>
+  <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.14.0.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script src="http://code.jquery.com/qunit/qunit-1.14.0.js"></script>
+  <script src="../history.js"></script>
+  <script src="test_hashchange.js"></script>
+</body>
+</html>

--- a/test/test_hashchange_nohtml5.html
+++ b/test/test_hashchange_nohtml5.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>QUnit Example</title>
+  <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.14.0.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script src="http://code.jquery.com/qunit/qunit-1.14.0.js"></script>
+  <script src="test_hashchange.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I believe this test demonstrates that the standard `hashchange` event is broken.

In `onHashChangeEvent`, `fireNow` and `lastURL` values are different, and appear to capture the last [sic] and next [sic] hash values.

```
function onHashChange(event) {
 // https://github.com/devote/HTML5-History-API/issues/46
 var fireNow = lastURL;
 // new value to lastURL
 lastURL = windowLocation.href;
```

e..g

```
> fireNow
"file:///home/user/workspace/HTML5-History-API/test/test_hashchange_html5.html"
> lastURL
"file:///home/user/workspace//HTML5-History-API/test/test_hashchange_html5.html#/path"
```

however, later, the `lastURL` and `newURL` values are compared, and they are identical

```
var oldURLObject = parseURL(lastURL, true);
var newURLObject = parseURL();
...
if (oldURLObject._hash !== newURLObject._hash) {
  // if current hash not equal previous hash
  dispatchEvent(event);
}
```

and the event is never fired.
