### PR TITLE
Making history.state to be returned as copy, not reference in IE 8,9

### DIFF
--- a/history.ielte7.js
+++ b/history.ielte7.js
@@ -240,7 +240,13 @@
          */
         "state": {
             get: function() {
-                return stateStorage[windowLocation.href] || null;
+                if (typeof stateStorage[windowLocation.href] === 'object') {
+					return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
+				} else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
+					return stateStorage[windowLocation.href];
+				} else {
+					return null;
+				}
             }
         }
     };

--- a/history.ielte7.js
+++ b/history.ielte7.js
@@ -241,12 +241,12 @@
         "state": {
             get: function() {
                 if (typeof stateStorage[windowLocation.href] === 'object') {
-					return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
-				} else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
-					return stateStorage[windowLocation.href];
-				} else {
-					return null;
-				}
+                    return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
+                } else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
+                    return stateStorage[windowLocation.href];
+                } else {
+                    return null;
+                }
             }
         }
     };

--- a/history.js
+++ b/history.js
@@ -240,7 +240,13 @@
          */
         "state": {
             get: function() {
-                return typeof stateStorage[windowLocation.href] === 'object' ? JSON.parse(JSON.stringify(stateStorage[windowLocation.href])) : (stateStorage[windowLocation.href] || null);
+                if (typeof stateStorage[windowLocation.href] === 'object') {
+					return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
+				} else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
+					return stateStorage[windowLocation.href];
+				} else {
+					return null;
+				}
             }
         }
     };

--- a/history.js
+++ b/history.js
@@ -241,12 +241,12 @@
         "state": {
             get: function() {
                 if (typeof stateStorage[windowLocation.href] === 'object') {
-					return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
-				} else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
-					return stateStorage[windowLocation.href];
-				} else {
-					return null;
-				}
+                    return JSON.parse(JSON.stringify(stateStorage[windowLocation.href]));
+                } else if(typeof stateStorage[windowLocation.href] !== 'undefined') {
+                    return stateStorage[windowLocation.href];
+                } else {
+                    return null;
+                }
             }
         }
     };

--- a/history.js
+++ b/history.js
@@ -240,7 +240,7 @@
          */
         "state": {
             get: function() {
-                return stateStorage[windowLocation.href] || null;
+                return typeof stateStorage[windowLocation.href] === 'object' ? JSON.parse(JSON.stringify(stateStorage[windowLocation.href])) : (stateStorage[windowLocation.href] || null);
             }
         }
     };


### PR DESCRIPTION
This closes https://github.com/devote/HTML5-History-API/issues/84