### PR TITLE
bind addEventListener, removeEventListener, and dispatchEvent for browsers that support EventTarget

### DIFF
--- a/history.js
+++ b/history.js
@@ -77,9 +77,9 @@
   // String that will contain the name of the method
   var dispatchEventName = global.dispatchEvent ? 'dispatchEvent' : 'fireEvent';
   // reference native methods for the events
-  var addEvent = global[addEventListenerName];
-  var removeEvent = global[removeEventListenerName];
-  var dispatch = global[dispatchEventName];
+  var addEvent = maybeBindToWindow(global[addEventListenerName]);
+  var removeEvent = maybeBindToWindow(global[removeEventListenerName]);
+  var dispatch = maybeBindToWindow(global[dispatchEventName]);
   // default settings
   var settings = {"basepath": '/', "redirect": 0, "type": '/', "init": 0};
   // key for the sessionStorage
@@ -497,6 +497,22 @@
     }
     // Return the regular check
     return !!historyPushState;
+  }
+
+  /**
+   * This method attempts to bind a function to global.
+   *
+   * @param {Function} [func] The function to be bound
+   * @return {Function} Returns the bound function or func
+   */
+  function maybeBindToWindow(func) {
+    if (window &&
+        window.EventTarget &&
+        typeof window.EventTarget.prototype.addEventListener === 'function' &&
+        typeof func.bind === 'function') {
+      return func.bind(window);
+    }
+    return func;
   }
 
   /**


### PR DESCRIPTION
In supporting browsers (Chrome, Safari, Edge, Firefox), third-party script loaded in an IFRAME that wraps `EventTarget.prototype.addEventListener` will lose track of the context of `this`, and will incorrectly bind the handler to its own IFRAME (instead of `top`).

## Reproducible Case
To reproduce the issue, go [here](http://cvazac.netlify.com/history.js) with the console open.
Without the fix, you will only see only 2 handlers fire:
```
first load handler fired
second load handler fired
```

To see the fix in action, go [here](http://cvazac.netlify.com/history.js/?fix).
You will see:
```
first load handler fired
second load handler fired
third load handler fired
```

## Why this happens
in `history.js`:
```
window.addEventListener = addEventListener
```

in an IFRAME:
```
top.EventTarget.prototype.addEventListener = (function(_addEventListener){
  return function(){
    return _addEventListener.apply(this, arguments)
  }
})(top.EventTarget.prototype.addEventListener)
```

developer code in `top`:
```
window.addEventListener('load', callback)
```

Because `history.js` basically unbinds the `window.addEventListener` method, `this` passed to the `_addEventListener.apply` call will be the inner IFRAME (should be `=== top`), and the `load` listener will be bound to the wrong `window`.